### PR TITLE
Directory may not exist

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -26,7 +26,6 @@ case node['platform']
         
         [Service]
         User=#{node['pgbouncer']['os_user']}
-        WorkingDirectory=/home/#{node['pgbouncer']['os_user']}
         ExecStart=#{node['pgbouncer']['source']['install_dir']}/bin/pgbouncer /etc/pgbouncer/pgbouncer.ini
         ExecReload=#{node['pgbouncer']['source']['install_dir']}/bin/pgbouncer -R /etc/pgbouncer/pgbouncer.ini
         Restart=always


### PR DESCRIPTION
The removed line assumes a `/home` directory exists for the user running pgbouncer, but that's a poor assumption given a lot of system users have their home directory elsewhere.  Simply leaving the WorkingDirectory line out of the systemd configuration causes it to use the given user's home directory by default, sidestepping the need to set it altogether.  From the manpage: "If not set, defaults to the root directory when systemd is running as a system instance and the respective user's home directory if run as user."